### PR TITLE
Buy It Now Button Fix

### DIFF
--- a/class-wcv-simple-auctions.php
+++ b/class-wcv-simple-auctions.php
@@ -170,6 +170,7 @@ class WC_Vendors_Simple_Auctions {
 			if ( isset( $_POST['_buy_it_now_price'] ) ) { 
 				update_post_meta( $post_id, '_buy_it_now_price', stripslashes( $_POST['_buy_it_now_price'] ) );
 				update_post_meta( $post_id, '_regular_price', stripslashes( $_POST['_buy_it_now_price'] ) );
+				update_post_meta( $post_id, '_price', intval(stripslashes( $_POST['_buy_it_now_price']) ) );
 			}
 
 			if ( isset( $_POST['_regular_price'] ) ) { 


### PR DESCRIPTION
This takes care of an issue regarding the buy-it-now button not showing up until the product is saved again.
The issue was discussed here:
https://www.wcvendors.com/help/topic/_buy_it_now_price-button-doesnt-appear-after-create-auction/

Currently i'm updating '_price' and '_buy_it_now_price' by adding an action to wcv_save_product.
For some reason it works in this code by only updating '_price'.